### PR TITLE
Changed return fpr type=='enum'

### DIFF
--- a/gql_schema_codegen/block/block.py
+++ b/gql_schema_codegen/block/block.py
@@ -31,8 +31,8 @@ class Block(BaseInfo):
         if self.type == 'enum':
             self.dependency_group.add_dependency(
                 Dependency(imported_from='enum', dependency='Enum'))
-            return f"{display_name} = Enum('{display_name}', '{' '.join(map(lambda f: f.name, self.fields))}')"
-
+	    return f"{display_name} = Enum('{display_name}', {[value for value in (map(lambda f: f.name, self.fields))]})"	
+	
         self.dependency_group.add_dependency(Dependency(
             imported_from='typing', dependency='TypedDict'))
         return f"{display_name} = TypedDict('{display_name}', {'{'}"


### PR DESCRIPTION
The string generation for enum was incorect and resultet in strings in form: 
Enum(display_name, 'field, field, field').
Is now: 
Enum(display_name, ['field', 'field', 'field']),
as it should be as per https://docs.python.org/3/library/enum.html. 